### PR TITLE
Improve autossh procd uci

### DIFF
--- a/net/autossh/Makefile
+++ b/net/autossh/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=autossh
 PKG_VERSION:=1.4g
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=https://www.harding.motd.ca/autossh/

--- a/net/autossh/files/autossh.hotplug
+++ b/net/autossh/files/autossh.hotplug
@@ -7,8 +7,4 @@
 		/etc/init.d/autossh start
 	}
 
-	[ "$ACTION" = "ifdown" ] && {
-		/etc/init.d/autossh stop
-	}
-
 }

--- a/net/autossh/files/autossh.init
+++ b/net/autossh/files/autossh.init
@@ -6,23 +6,74 @@ START=80
 
 start_instance() {
 	local section="$1"
+	local forwarding
 
-	config_get ssh "$section" 'ssh'
-	config_get gatetime "$section" 'gatetime'
-	config_get monitorport "$section" 'monitorport'
-	config_get poll "$section" 'poll'
-	config_get_bool enabled "$section" 'enabled' '1'
+	config_get_bool enabled     "$section" enabled 1
+	[ "$enabled" != "1" ] && return 0
 
-	[ "$enabled" = 1 ] || exit 0
+	config_get ssh              "$section" ssh
+	if [ -z "$ssh" ]; then
+		echo "autossh: ssh option is required"
+		return 1
+	fi
 
-	procd_open_instance
-	procd_set_param command /usr/sbin/autossh -M ${monitorport:-20000} ${ssh}
+	config_get localhost       "$section" localhost localhost
+	config_get localport       "$section" localport
+	config_get remotehost      "$section" remotehost
+	config_get remoteport      "$section" remoteport
+	config_get monitorport     "$section" monitorport 20000
+	config_get poll            "$section" poll 600
+	config_get gatetime        "$section" gatetime 30
+	config_get first_poll      "$section" first_poll 
+	config_get loglevel        "$section" loglevel
+	config_get logfile         "$section" logfile
+	config_get maxlifetime     "$section" maxlifetime
+	config_get maxstart        "$section" maxstart
+	config_get message         "$section" message
+	config_get_bool ntservice  "$section" ntservice 0
+	config_get path            "$section" path
+	config_get pidfile         "$section" pidfile
+
+	if [ -z "$localport" ]; then
+		echo "autossh: localport option is required"
+		return 1
+	fi
+
+	if [ -n "$remotehost" ]; then
+		forwarding="-L ${localport}:${remotehost}:${remoteport}"
+	else
+		forwarding="-R ${remoteport}:${localhost}:${localport}"
+	fi
+
+	procd_open_instance "$section"
+	procd_set_param command /usr/sbin/autossh ${forwarding} ${ssh}
 	procd_set_param respawn ${respawn_threshold:-3600} ${respawn_timeout:-5} ${respawn_retry:-5}
-	procd_set_param env AUTOSSH_GATETIME="${gatetime:-30}" AUTOSSH_POLL="${poll:-600}"
+	[ -n "$pidfile" ] && procd_set_param pidfile "$pidfile"
+
+	[ -n "$monitorport" ] && procd_append_param env "AUTOSSH_PORT=$monitorport"
+	[ -n "$poll" ] && procd_append_param env "AUTOSSH_POLL=$poll"
+	[ -n "$gatetime" ] && procd_append_param env "AUTOSSH_GATETIME=$gatetime"
+	[ -n "$first_poll" ] && procd_append_param env "AUTOSSH_FIRST_POLL=$first_poll"
+	[ -n "$loglevel" ] && procd_append_param env "AUTOSSH_LOGLEVEL=$loglevel"
+	[ -n "$logfile" ] && procd_append_param env "AUTOSSH_LOGFILE=$logfile"
+	[ -n "$maxlifetime" ] && procd_append_param env "AUTOSSH_MAXLIFETIME=$maxlifetime"
+	[ -n "$maxstart" ] && procd_append_param env "AUTOSSH_MAXSTART=$maxstart"
+	[ -n "$message" ] && procd_append_param env "AUTOSSH_MESSAGE=$message"
+	[ "$ntservice" == "1" ] && procd_append_param env "AUTOSSH_NTSERVICE=yes"
+	[ -n "$path" ] && procd_append_param env "AUTOSSH_PATH=$path"
+	[ -n "$pidfile" ] && procd_append_param env "AUTOSSH_PIDFILE=$pidfile"
+
 	procd_close_instance
 }
 
 start_service() {
+	local instance=$1
+
 	config_load 'autossh'
-	config_foreach start_instance 'autossh'
+
+	if [ -n "$instance" ]; then
+		start_instance "$1"
+	else
+		config_foreach start_instance 'autossh'
+	fi
 }


### PR DESCRIPTION
- convert autossh into procd instances
- add new uci config options to handle local and remote
  port forwarding
- remove hotplug down actions causing service to stop on
  any interface down event

Maintainer: @neheb 
Compile tested: (x86_64, VirtualBox, OpenWrt v21.02.3)
Run tested: (x86_64, VirtualBox, OpenWrt v21.02.3, tests done)

Description:
Service gets stopped whenever any of the interfaces trigger down
Convert autossh into procd instances
Add new autossh config options in UCI to handle ssh port forwarding